### PR TITLE
feat: added max slippage into tariswap tests

### DIFF
--- a/templates/tariswap/Cargo.lock
+++ b/templates/tariswap/Cargo.lock
@@ -2482,8 +2482,10 @@ dependencies = [
 name = "tariswap"
 version = "0.1.0"
 dependencies = [
+ "anyhow",
  "serde",
  "tari_bor",
+ "tari_dan_engine",
  "tari_engine_types",
  "tari_template_lib",
  "tari_template_test_tooling",

--- a/templates/tariswap/Cargo.toml
+++ b/templates/tariswap/Cargo.toml
@@ -13,3 +13,5 @@ tari_template_test_tooling = { git = "https://github.com/tari-project/tari-dan.g
 tari_transaction = { git = "https://github.com/tari-project/tari-dan.git", branch = "development" }
 tari_bor = { git = "https://github.com/tari-project/tari-dan.git", branch = "development" }
 tari_engine_types = { git = "https://github.com/tari-project/tari-dan.git", branch = "development" }
+tari_dan_engine = { git = "https://github.com/tari-project/tari-dan.git", branch = "development" }
+anyhow = "1.0.86"


### PR DESCRIPTION
* Used the new `AssertBucketContains` instruction in all `swap` operations to ensure the amount of tokens the user gets in return
* New unit test to ensure that a transaction failure happens when the amount of tokens returned after a `swap` is below the minimum amount the user specified